### PR TITLE
Add tt-metal as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ data/
 build/
 .venv/
 .idea/
+third_party/tt-metal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,10 @@ if(APPLE)
     message(STATUS "Using macOS SDK: ${CMAKE_OSX_SYSROOT}")
 endif()
 
-project(wormhole CXX)
+project(wormhole C CXX)
 set(CMAKE_CXX_STANDARD 20)
+
+option(BUILD_WORMHOLE_DECISION_TREE "Build wormhole implementation of decision tree" OFF)
 
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isysroot ${CMAKE_OSX_SYSROOT} -stdlib=libc++ -I${CMAKE_OSX_SYSROOT}/usr/include/c++/v1")
@@ -23,13 +25,14 @@ endif()
 
 include(FetchContent)
 
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(
         benchmark
         GIT_REPOSITORY https://github.com/google/benchmark.git
         GIT_TAG main
 )
-set(BENCHMARK_ENABLE_TESTING OFF)
-set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
 
 
 FetchContent_Declare(
@@ -118,3 +121,9 @@ target_link_libraries(plot_result
         PRIVATE test_tree_final
         PRIVATE nlohmann_json::nlohmann_json
 )
+
+add_subdirectory(third_party)
+
+if (BUILD_WORMHOLE_DECISION_TREE)
+        add_subdirectory(decision_tree_WH)
+endif()

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ make -j8
 Compile project with wormhole implementation:
 ```bash
 export ARCH_NAME=wormhole_b0
-export TT_METAL_HOME=$(realpath ./third_party/tt-metal/src/tt-metal)
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WORMHOLE_DECISION_TREE=ON ../
+make -j8
+cd ../
+export TT_METAL_HOME=$(realpath ./third_party/tt-metal/src/tt-metal)
 ```
 
 ### Running

--- a/README.md
+++ b/README.md
@@ -36,11 +36,19 @@ and to train forest:
 python forest.py <train_file_csv> <test_file_csv> <forest_output_file_json> <predictions_output_file_forest_csv>
 ```
 
-Compile project:
+Compile project without wormhole implementation:
 ```bash
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ../
 make -j8
+```
+
+Compile project with wormhole implementation:
+```bash
+export ARCH_NAME=wormhole_b0
+export TT_METAL_HOME=$(realpath ./third_party/tt-metal/src/tt-metal)
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WORMHOLE_DECISION_TREE=ON ../
 ```
 
 ### Running

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ make -j8
 
 Compile project with wormhole implementation:
 ```bash
-export ARCH_NAME=wormhole_b0
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WORMHOLE_DECISION_TREE=ON ../
 make -j8

--- a/decision_tree_WH/CMakeLists.txt
+++ b/decision_tree_WH/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(add_2_integers_in_compute_example add_2_integers_in_compute/add_2_integers_in_compute.cpp)
+target_link_libraries(add_2_integers_in_compute_example PRIVATE tt-metal-fullt)

--- a/decision_tree_WH/CMakeLists.txt
+++ b/decision_tree_WH/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(add_2_integers_in_compute_example add_2_integers_in_compute/add_2_integers_in_compute.cpp)
-target_link_libraries(add_2_integers_in_compute_example PRIVATE tt-metal-fullt)
+target_link_libraries(add_2_integers_in_compute_example PRIVATE tt-metal-full)

--- a/decision_tree_WH/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -57,7 +57,7 @@ int main() {
 
     /* Specify data movement kernels for reading/writing data to/from DRAM */
     // TODO: maybe there is better way of setting path to kernels?
-    const std::string rel_path_to_kernels = "../../../..//add_2_integers_in_compute/kernels/";
+    const std::string rel_path_to_kernels = "../../../../decision_tree_WH/add_2_integers_in_compute/kernels/";
     KernelHandle binary_reader_kernel_id = CreateKernel(
         program,
         rel_path_to_kernels + "dataflow/reader_binary_1_tile.cpp",

--- a/decision_tree_WH/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/bfloat16.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+int main() {
+    /* Silicon accelerator setup */
+    IDevice* device = CreateDevice(0);
+
+    /* Setup program to execute along with its buffers and kernels to use */
+    CommandQueue& cq = device->command_queue();
+    Program program = CreateProgram();
+    constexpr CoreCoord core = {0, 0};
+
+    constexpr uint32_t single_tile_size = 2 * 1024;
+    tt_metal::InterleavedBufferConfig dram_config{
+        .device = device,
+        .size = single_tile_size,
+        .page_size = single_tile_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
+
+    std::shared_ptr<tt::tt_metal::Buffer> src0_dram_buffer = CreateBuffer(dram_config);
+    std::shared_ptr<tt::tt_metal::Buffer> src1_dram_buffer = CreateBuffer(dram_config);
+    std::shared_ptr<tt::tt_metal::Buffer> dst_dram_buffer = CreateBuffer(dram_config);
+
+    // Since all interleaved buffers have size == page_size, they are entirely contained in the first DRAM bank
+    uint32_t src0_bank_id = 0;
+    uint32_t src1_bank_id = 0;
+    uint32_t dst_bank_id = 0;
+
+    /* Use L1 circular buffers to set input and output buffers that the compute engine will use */
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    constexpr uint32_t num_input_tiles = 1;
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    CBHandle cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    constexpr uint32_t src1_cb_index = CBIndex::c_1;
+    CircularBufferConfig cb_src1_config =
+        CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src1_cb_index, single_tile_size);
+    CBHandle cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+
+    constexpr uint32_t output_cb_index = CBIndex::c_16;
+    constexpr uint32_t num_output_tiles = 1;
+    CircularBufferConfig cb_output_config =
+        CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(output_cb_index, single_tile_size);
+    CBHandle cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+
+    /* Specify data movement kernels for reading/writing data to/from DRAM */
+    // TODO: maybe there is better way of setting path to kernels?
+    const std::string rel_path_to_kernels = "../../../..//add_2_integers_in_compute/kernels/";
+    KernelHandle binary_reader_kernel_id = CreateKernel(
+        program,
+        rel_path_to_kernels + "dataflow/reader_binary_1_tile.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        rel_path_to_kernels + "dataflow/writer_1_tile.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    /* Set the parameters that the compute kernel will use */
+    std::vector<uint32_t> compute_kernel_args = {};
+
+    /* Use the add_tiles operation in the compute kernel */
+    KernelHandle eltwise_binary_kernel_id = CreateKernel(
+        program,
+        rel_path_to_kernels + "compute/add_2_tiles.cpp",
+        core,
+        ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compute_kernel_args,
+        });
+
+    /* Create source data and write to DRAM */
+    std::vector<uint32_t> src0_vec;
+    std::vector<uint32_t> src1_vec;
+    src0_vec = create_constant_vector_of_bfloat16(single_tile_size, 14.0f);
+    src1_vec = create_constant_vector_of_bfloat16(single_tile_size, 8.0f);
+
+    EnqueueWriteBuffer(cq, src0_dram_buffer, src0_vec, false);
+    EnqueueWriteBuffer(cq, src1_dram_buffer, src1_vec, false);
+
+    /* Configure program and runtime kernel arguments, then execute */
+    SetRuntimeArgs(
+        program,
+        binary_reader_kernel_id,
+        core,
+        {src0_dram_buffer->address(), src1_dram_buffer->address(), src0_bank_id, src1_bank_id});
+    SetRuntimeArgs(program, eltwise_binary_kernel_id, core, {});
+    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address(), dst_bank_id});
+
+    EnqueueProgram(cq, program, false);
+    Finish(cq);
+
+    /* Read in result into a host vector */
+    std::vector<uint32_t> result_vec;
+    EnqueueReadBuffer(cq, dst_dram_buffer, result_vec, true);
+
+    printf("Result = %d\n", result_vec[0]);  // 22 = 1102070192
+    printf(
+        "Expected = %d\n",
+        pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfloat16(22.0f), bfloat16(22.0f))));
+    CloseDevice(device);
+}

--- a/decision_tree_WH/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init(cb_in0, cb_in1);
+
+    // wait for a block of tiles in each of input CBs
+    cb_wait_front(cb_in0, 1);
+    cb_wait_front(cb_in1, 1);
+
+    tile_regs_acquire();  // acquire 8 tile registers
+
+    add_tiles(cb_in0, cb_in1, 0, 0, 0);
+
+    tile_regs_commit();  // signal the packer
+
+    tile_regs_wait();  // packer waits here
+    pack_tile(0, cb_out0);
+    tile_regs_release();  // packer releases
+
+    cb_pop_front(cb_in0, 1);
+    cb_pop_front(cb_in1, 1);
+
+    cb_push_back(cb_out0, 1);
+}
+}  // namespace NAMESPACE

--- a/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t src0_bank_id = get_arg_val<uint32_t>(2);
+    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);
+
+    uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_bank_id, src0_addr);
+    uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_bank_id, src1_addr);
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+
+    // single-tile ublocks
+    uint32_t ublock_size_bytes_0 = get_tile_size(cb_id_in0);
+    uint32_t ublock_size_bytes_1 = get_tile_size(cb_id_in1);
+
+    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+    uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+
+    // read ublocks from src0/src1 to CB0/CB1, then push ublocks to compute (unpacker)
+    cb_reserve_back(cb_id_in0, 1);
+    noc_async_read(src0_noc_addr, l1_write_addr_in0, ublock_size_bytes_0);
+    noc_async_read_barrier();
+    cb_push_back(cb_id_in0, 1);
+
+    cb_reserve_back(cb_id_in1, 1);
+    noc_async_read(src1_noc_addr, l1_write_addr_in1, ublock_size_bytes_1);
+    noc_async_read_barrier();
+    cb_push_back(cb_id_in1, 1);
+}

--- a/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_bank_id = get_arg_val<uint32_t>(1);
+
+    uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_addr);
+
+    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
+    uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
+    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+
+    cb_wait_front(cb_id_out0, 1);
+    noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
+    noc_async_write_barrier();
+    cb_pop_front(cb_id_out0, 1);
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,105 @@
+# Inspired by https://github.com/tenstorrent/tt-mlir/blob/b55b6b0fb4149c7bc50d4d467d8fc9964ef082a5/third_party/CMakeLists.txt
+
+# Set architecture
+if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
+  set(ARCH_NAME "grayskull")
+  set(ARCH_EXTRA_DIR "grayskull")
+elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
+  set(ARCH_NAME "wormhole")
+  set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
+elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
+  set(ARCH_NAME "blackhole")
+  set(ARCH_EXTRA_DIR "blackhole")
+else()
+  message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
+endif()
+
+set(TTMETAL_INCLUDE_DIRS
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/deprecated
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/api
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hostdevcommon/api
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/device/api
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6//include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+)
+
+
+set(TT_METAL_VERSION "v0.57.0-rc69")
+set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
+
+set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/")
+
+set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/lib)
+set(TTNN_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/_ttnn.so)
+set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libtt_metal.so)
+set(DEVICE_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libdevice.so)
+
+set(TTMETAL_LIBRARY_DIR ${TTMETAL_LIBRARY_DIR} PARENT_SCOPE)
+set(TTNN_LIBRARY_PATH ${TTNN_LIBRARY_PATH} PARENT_SCOPE)
+set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_PATH} PARENT_SCOPE)
+set(DEVICE_LIBRARY_PATH ${DEVICE_LIBRARY_PATH} PARENT_SCOPE)
+
+
+include(ExternalProject)
+ExternalProject_Add(
+  tt-metal
+  PREFIX ${PROJECT_SOURCE_DIR}/third_party/tt-metal
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_MESSAGE=LAZY
+  UPDATE_COMMAND
+    git submodule update --init --recursive &&
+    git submodule foreach "git lfs fetch --all && git lfs pull"
+  CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX=${METAL_INSTALL_PREFIX}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+    -DCMAKE_CXX_FLAGS="-Wno-dangling-reference" # Required to build with GCC
+    -DENABLE_CCACHE=ON
+    -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+    -DENABLE_TRACY=OFF
+    -DENABLE_LIBCXX=OFF
+  GIT_REPOSITORY https://github.com/tenstorrent/tt-metal.git
+  GIT_TAG ${TT_METAL_VERSION}
+  GIT_PROGRESS ON
+  BUILD_BYPRODUCTS ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH}
+)
+
+ExternalProject_Add_StepTargets(tt-metal download configure)
+
+list(APPEND library_names TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
+list(APPEND library_paths ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH})
+
+foreach(lib_name lib_path IN ZIP_LISTS library_names library_paths)
+  add_library(${lib_name} SHARED IMPORTED GLOBAL)
+  set_target_properties(${lib_name} PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${lib_path})
+  add_dependencies(${lib_name} tt-metal)
+endforeach()
+
+# Now create a logical interface library
+add_library(tt-metal-full INTERFACE)
+
+# Link the .so files into it
+target_link_libraries(tt-metal-full INTERFACE TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
+
+# Now all the incudes
+target_include_directories(tt-metal-full INTERFACE ${TTMETAL_INCLUDE_DIRS})

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,21 +1,7 @@
 # Inspired by https://github.com/tenstorrent/tt-mlir/blob/b55b6b0fb4149c7bc50d4d467d8fc9964ef082a5/third_party/CMakeLists.txt
 
 if (BUILD_WORMHOLE_DECISION_TREE)
-  # Set architecture
-  if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
-    set(ARCH_NAME "grayskull")
-    set(ARCH_EXTRA_DIR "grayskull")
-  elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
-    set(ARCH_NAME "wormhole")
-    set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
-  elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
-    set(ARCH_NAME "blackhole")
-    set(ARCH_EXTRA_DIR "blackhole")
-  else()
-    message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
-  endif()
-
-  set(TTMETAL_INCLUDE_DIRS
+set(TTMETAL_INCLUDE_DIRS
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/deprecated
@@ -26,8 +12,6 @@ if (BUILD_WORMHOLE_DECISION_TREE)
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/device/api
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc
-      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
-      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
       ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,105 +1,108 @@
 # Inspired by https://github.com/tenstorrent/tt-mlir/blob/b55b6b0fb4149c7bc50d4d467d8fc9964ef082a5/third_party/CMakeLists.txt
 
-# Set architecture
-if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
-  set(ARCH_NAME "grayskull")
-  set(ARCH_EXTRA_DIR "grayskull")
-elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
-  set(ARCH_NAME "wormhole")
-  set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
-elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
-  set(ARCH_NAME "blackhole")
-  set(ARCH_EXTRA_DIR "blackhole")
-else()
-  message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
+if (BUILD_WORMHOLE_DECISION_TREE)
+  # Set architecture
+  if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
+    set(ARCH_NAME "grayskull")
+    set(ARCH_EXTRA_DIR "grayskull")
+  elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
+    set(ARCH_NAME "wormhole")
+    set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
+  elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
+    set(ARCH_NAME "blackhole")
+    set(ARCH_EXTRA_DIR "blackhole")
+  else()
+    message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
+  endif()
+
+  set(TTMETAL_INCLUDE_DIRS
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/deprecated
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/api
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hostdevcommon/api
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/device/api
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6//include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
+      ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+      # PARENT_SCOPE
+  )
+
+
+  set(TT_METAL_VERSION "v0.57.0-rc69")
+  set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
+
+  set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/")
+
+  set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/lib)
+  set(TTNN_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/_ttnn.so)
+  set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libtt_metal.so)
+  set(DEVICE_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libdevice.so)
+
+  set(TTMETAL_LIBRARY_DIR ${TTMETAL_LIBRARY_DIR} PARENT_SCOPE)
+  set(TTNN_LIBRARY_PATH ${TTNN_LIBRARY_PATH} PARENT_SCOPE)
+  set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_PATH} PARENT_SCOPE)
+  set(DEVICE_LIBRARY_PATH ${DEVICE_LIBRARY_PATH} PARENT_SCOPE)
+
+
+  include(ExternalProject)
+  ExternalProject_Add(
+    tt-metal
+    PREFIX ${PROJECT_SOURCE_DIR}/third_party/tt-metal
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_MESSAGE=LAZY
+    UPDATE_COMMAND
+      git submodule update --init --recursive &&
+      git submodule foreach "git lfs fetch --all && git lfs pull"
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DCMAKE_INSTALL_PREFIX=${METAL_INSTALL_PREFIX}
+      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+      -DCMAKE_CXX_FLAGS="-Wno-dangling-reference" # Required to build with GCC
+      -DENABLE_CCACHE=ON
+      -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+      -DENABLE_TRACY=OFF
+      -DENABLE_LIBCXX=OFF
+    GIT_REPOSITORY https://github.com/tenstorrent/tt-metal.git
+    GIT_TAG ${TT_METAL_VERSION}
+    GIT_PROGRESS ON
+    BUILD_BYPRODUCTS ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH}
+  )
+
+  ExternalProject_Add_StepTargets(tt-metal download configure)
+
+  list(APPEND library_names TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
+  list(APPEND library_paths ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH})
+
+  foreach(lib_name lib_path IN ZIP_LISTS library_names library_paths)
+    add_library(${lib_name} SHARED IMPORTED GLOBAL)
+    set_target_properties(${lib_name} PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${lib_path})
+    add_dependencies(${lib_name} tt-metal)
+  endforeach()
+
+  # Now create a logical interface library
+  add_library(tt-metal-full INTERFACE)
+
+  # Link the .so files into it
+  target_link_libraries(tt-metal-full INTERFACE TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
+
+  # Now all the incudes
+  target_include_directories(tt-metal-full INTERFACE "${TTMETAL_INCLUDE_DIRS}")
 endif()
-
-set(TTMETAL_INCLUDE_DIRS
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/deprecated
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/api
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hostdevcommon/api
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/device/api
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6//include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
-)
-
-
-set(TT_METAL_VERSION "v0.57.0-rc69")
-set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
-
-set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/")
-
-set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/lib)
-set(TTNN_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/_ttnn.so)
-set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libtt_metal.so)
-set(DEVICE_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libdevice.so)
-
-set(TTMETAL_LIBRARY_DIR ${TTMETAL_LIBRARY_DIR} PARENT_SCOPE)
-set(TTNN_LIBRARY_PATH ${TTNN_LIBRARY_PATH} PARENT_SCOPE)
-set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_PATH} PARENT_SCOPE)
-set(DEVICE_LIBRARY_PATH ${DEVICE_LIBRARY_PATH} PARENT_SCOPE)
-
-
-include(ExternalProject)
-ExternalProject_Add(
-  tt-metal
-  PREFIX ${PROJECT_SOURCE_DIR}/third_party/tt-metal
-  CMAKE_ARGS
-    -DCMAKE_INSTALL_MESSAGE=LAZY
-  UPDATE_COMMAND
-    git submodule update --init --recursive &&
-    git submodule foreach "git lfs fetch --all && git lfs pull"
-  CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    -DCMAKE_INSTALL_PREFIX=${METAL_INSTALL_PREFIX}
-    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-    -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-    -DCMAKE_CXX_FLAGS="-Wno-dangling-reference" # Required to build with GCC
-    -DENABLE_CCACHE=ON
-    -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
-    -DENABLE_TRACY=OFF
-    -DENABLE_LIBCXX=OFF
-  GIT_REPOSITORY https://github.com/tenstorrent/tt-metal.git
-  GIT_TAG ${TT_METAL_VERSION}
-  GIT_PROGRESS ON
-  BUILD_BYPRODUCTS ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH}
-)
-
-ExternalProject_Add_StepTargets(tt-metal download configure)
-
-list(APPEND library_names TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
-list(APPEND library_paths ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH})
-
-foreach(lib_name lib_path IN ZIP_LISTS library_names library_paths)
-  add_library(${lib_name} SHARED IMPORTED GLOBAL)
-  set_target_properties(${lib_name} PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${lib_path})
-  add_dependencies(${lib_name} tt-metal)
-endforeach()
-
-# Now create a logical interface library
-add_library(tt-metal-full INTERFACE)
-
-# Link the .so files into it
-target_link_libraries(tt-metal-full INTERFACE TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
-
-# Now all the incudes
-target_include_directories(tt-metal-full INTERFACE ${TTMETAL_INCLUDE_DIRS})


### PR DESCRIPTION
**Description**
We need to use tt-metal as dependency, to develop wormhole decision tree on top of it. 

Using git submodules doesn't work well, since tt-metal doesn't export cmake target so it's hard to properly set dependencies in cmake (i.e. target using tt-metal shouldn't be compiled before tt-metal)

So, I just reused and updated for our purposes tt-mlir/tt-metal [integration](https://github.com/tenstorrent/tt-mlir/blob/b55b6b0fb4149c7bc50d4d467d8fc9964ef082a5/third_party/CMakeLists.txt#L21)

**What changed**
- Added third_party with CMakeLists.txt that fetches and build tt-metal, then finds all .so and includes and beautifully exposes them as tt-metal-full target. 
- Copy-pasted example for tt-metal `add_2_integers_in_compute_example`. You can see that the only think it does is linking with tt-metal-full
- Updated README with instructions on how to build
- Updated .gitignore with cloned tt-metal folder