### PR TITLE
Add tt-metal as dependency -- gitsubmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third-party/tt-metal"]
 	path = third-party/tt-metal
 	url = https://github.com/tenstorrent/tt-metal
+	branch = v0.57.0-rc69

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third-party/tt-metal"]
+	path = third-party/tt-metal
+	url = https://github.com/tenstorrent/tt-metal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ endif()
 project(wormhole CXX)
 set(CMAKE_CXX_STANDARD 20)
 
+option(BUILD_WORMHOLE_DECISION_TREE "Build wormhole implementation of decision tree" OFF)
+
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isysroot ${CMAKE_OSX_SYSROOT} -stdlib=libc++ -I${CMAKE_OSX_SYSROOT}/usr/include/c++/v1")
 endif()
@@ -23,14 +25,14 @@ endif()
 
 include(FetchContent)
 
+set(BENCHMARK_ENABLE_TESTING OFF)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+
 FetchContent_Declare(
         benchmark
         GIT_REPOSITORY https://github.com/google/benchmark.git
         GIT_TAG main
 )
-set(BENCHMARK_ENABLE_TESTING OFF)
-set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
-
 
 FetchContent_Declare(
         nlohmann_json
@@ -118,3 +120,8 @@ target_link_libraries(plot_result
         PRIVATE test_tree_final
         PRIVATE nlohmann_json::nlohmann_json
 )
+
+add_subdirectory(third-party)
+if (BUILD_WORMHOLE_DECISION_TREE)
+        add_subdirectory(decision_tree_WH)
+endif()

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WORMHOLE_DECISION_TREE=ON ../  # You ca
 make -j$(nproc)
 ```
 
-### Export those environment variables before running WH code: 
+### Export this environment variables before running WH code: 
 ```bash
-export ARCH_NAME=wormhole_b0
 export TT_METAL_HOME=$(realpath ./third-party/tt-metal/)
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To begin with, we provided some example csv files based on iris dataset, which o
 In train.csv there is a dataset which is used for training a tree/forest model in Python. 
 
 ### Build dependencies
-```
+```bash
 git submodule update --init --recursive
 git submodule foreach --recursive 'git lfs fetch --all && git lfs pull'
 ```
@@ -47,6 +47,12 @@ Compile project:
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WORMHOLE_DECISION_TREE=ON ../  # You can compile without WH if needed
 make -j$(nproc)
+```
+
+### Export those environment variables before running WH code: 
+```bash
+export ARCH_NAME=wormhole_b0
+export TT_METAL_HOME=$(realpath ./third-party/tt-metal/)
 ```
 
 ### Running

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ To begin with, we provided some example csv files based on iris dataset, which o
 
 In train.csv there is a dataset which is used for training a tree/forest model in Python. 
 
+### Build dependencies
+```
+git submodule update --init --recursive
+git submodule foreach --recursive 'git lfs fetch --all && git lfs pull'
+```
+
 ### Compilation
 Firstly, to train a tree run this:
 ```{bash}
@@ -39,8 +45,8 @@ python forest.py <train_file_csv> <test_file_csv> <forest_output_file_json> <pre
 Compile project:
 ```bash
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ../
-make -j8
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_WORMHOLE_DECISION_TREE=ON ../  # You can compile without WH if needed
+make -j$(nproc)
 ```
 
 ### Running

--- a/decision_tree_WH/CMakeLists.txt
+++ b/decision_tree_WH/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(add_2_integers_in_compute_example add_2_integers_in_compute/add_2_integers_in_compute.cpp)
-target_link_libraries(add_2_integers_in_compute_example PRIVATE tt-metal nlohmann_json::nlohmann_json)
+target_link_libraries(add_2_integers_in_compute_example PRIVATE Metalium::Metal)

--- a/decision_tree_WH/CMakeLists.txt
+++ b/decision_tree_WH/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(add_2_integers_in_compute_example add_2_integers_in_compute/add_2_integers_in_compute.cpp)
+target_link_libraries(add_2_integers_in_compute_example PRIVATE tt-metal nlohmann_json::nlohmann_json)

--- a/decision_tree_WH/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/bfloat16.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+int main() {
+    /* Silicon accelerator setup */
+    IDevice* device = CreateDevice(0);
+
+    /* Setup program to execute along with its buffers and kernels to use */
+    CommandQueue& cq = device->command_queue();
+    Program program = CreateProgram();
+    constexpr CoreCoord core = {0, 0};
+
+    constexpr uint32_t single_tile_size = 2 * 1024;
+    tt_metal::InterleavedBufferConfig dram_config{
+        .device = device,
+        .size = single_tile_size,
+        .page_size = single_tile_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
+
+    std::shared_ptr<tt::tt_metal::Buffer> src0_dram_buffer = CreateBuffer(dram_config);
+    std::shared_ptr<tt::tt_metal::Buffer> src1_dram_buffer = CreateBuffer(dram_config);
+    std::shared_ptr<tt::tt_metal::Buffer> dst_dram_buffer = CreateBuffer(dram_config);
+
+    // Since all interleaved buffers have size == page_size, they are entirely contained in the first DRAM bank
+    uint32_t src0_bank_id = 0;
+    uint32_t src1_bank_id = 0;
+    uint32_t dst_bank_id = 0;
+
+    /* Use L1 circular buffers to set input and output buffers that the compute engine will use */
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    constexpr uint32_t num_input_tiles = 1;
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    CBHandle cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    constexpr uint32_t src1_cb_index = CBIndex::c_1;
+    CircularBufferConfig cb_src1_config =
+        CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src1_cb_index, single_tile_size);
+    CBHandle cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+
+    constexpr uint32_t output_cb_index = CBIndex::c_16;
+    constexpr uint32_t num_output_tiles = 1;
+    CircularBufferConfig cb_output_config =
+        CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(output_cb_index, single_tile_size);
+    CBHandle cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+
+    /* Specify data movement kernels for reading/writing data to/from DRAM */
+    KernelHandle binary_reader_kernel_id = CreateKernel(
+        program,
+        "tt_metal/programming_examples/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        "tt_metal/programming_examples/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    /* Set the parameters that the compute kernel will use */
+    std::vector<uint32_t> compute_kernel_args = {};
+
+    /* Use the add_tiles operation in the compute kernel */
+    KernelHandle eltwise_binary_kernel_id = CreateKernel(
+        program,
+        "tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp",
+        core,
+        ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compute_kernel_args,
+        });
+
+    /* Create source data and write to DRAM */
+    std::vector<uint32_t> src0_vec;
+    std::vector<uint32_t> src1_vec;
+    src0_vec = create_constant_vector_of_bfloat16(single_tile_size, 14.0f);
+    src1_vec = create_constant_vector_of_bfloat16(single_tile_size, 8.0f);
+
+    EnqueueWriteBuffer(cq, src0_dram_buffer, src0_vec, false);
+    EnqueueWriteBuffer(cq, src1_dram_buffer, src1_vec, false);
+
+    /* Configure program and runtime kernel arguments, then execute */
+    SetRuntimeArgs(
+        program,
+        binary_reader_kernel_id,
+        core,
+        {src0_dram_buffer->address(), src1_dram_buffer->address(), src0_bank_id, src1_bank_id});
+    SetRuntimeArgs(program, eltwise_binary_kernel_id, core, {});
+    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address(), dst_bank_id});
+
+    EnqueueProgram(cq, program, false);
+    Finish(cq);
+
+    /* Read in result into a host vector */
+    std::vector<uint32_t> result_vec;
+    EnqueueReadBuffer(cq, dst_dram_buffer, result_vec, true);
+
+    printf("Result = %d\n", result_vec[0]);  // 22 = 1102070192
+    printf(
+        "Expected = %d\n",
+        pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfloat16(22.0f), bfloat16(22.0f))));
+    CloseDevice(device);
+}

--- a/decision_tree_WH/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init(cb_in0, cb_in1);
+
+    // wait for a block of tiles in each of input CBs
+    cb_wait_front(cb_in0, 1);
+    cb_wait_front(cb_in1, 1);
+
+    tile_regs_acquire();  // acquire 8 tile registers
+
+    add_tiles(cb_in0, cb_in1, 0, 0, 0);
+
+    tile_regs_commit();  // signal the packer
+
+    tile_regs_wait();  // packer waits here
+    pack_tile(0, cb_out0);
+    tile_regs_release();  // packer releases
+
+    cb_pop_front(cb_in0, 1);
+    cb_pop_front(cb_in1, 1);
+
+    cb_push_back(cb_out0, 1);
+}
+}  // namespace NAMESPACE

--- a/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t src0_bank_id = get_arg_val<uint32_t>(2);
+    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);
+
+    uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_bank_id, src0_addr);
+    uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_bank_id, src1_addr);
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+
+    // single-tile ublocks
+    uint32_t ublock_size_bytes_0 = get_tile_size(cb_id_in0);
+    uint32_t ublock_size_bytes_1 = get_tile_size(cb_id_in1);
+
+    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+    uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+
+    // read ublocks from src0/src1 to CB0/CB1, then push ublocks to compute (unpacker)
+    cb_reserve_back(cb_id_in0, 1);
+    noc_async_read(src0_noc_addr, l1_write_addr_in0, ublock_size_bytes_0);
+    noc_async_read_barrier();
+    cb_push_back(cb_id_in0, 1);
+
+    cb_reserve_back(cb_id_in1, 1);
+    noc_async_read(src1_noc_addr, l1_write_addr_in1, ublock_size_bytes_1);
+    noc_async_read_barrier();
+    cb_push_back(cb_id_in1, 1);
+}

--- a/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp
+++ b/decision_tree_WH/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_bank_id = get_arg_val<uint32_t>(1);
+
+    uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_addr);
+
+    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
+    uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
+    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+
+    cb_wait_front(cb_id_out0, 1);
+    noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
+    noc_async_write_barrier();
+    cb_pop_front(cb_id_out0, 1);
+}

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,0 +1,89 @@
+# Some flags for tt-metal -- ccache + export compile commands for IDE if needed
+set(CMAKE_DISABLE_PRECOMPILE_HEADERS TRUE)
+set(ENABLE_CCACHE TRUE)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+set(TT_UNITY_BUILDS OFF)
+set(CPM_SOURCE_CACHE "${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache" CACHE STRING "Path to CPM source cache")
+
+# Save previous CMake CXX flags
+set(_PREV_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-dangling-reference")
+endif()
+
+add_subdirectory(tt-metal)
+
+# Restore previous CMake CXX flags
+set(CMAKE_CXX_FLAGS "${_PREV_CMAKE_CXX_FLAGS}")
+unset(_PREV_CMAKE_CXX_FLAGS)
+
+
+# Now wrap all the headers and .so files nicely into one target
+
+add_library(_tt-metal SHARED IMPORTED GLOBAL)
+set_target_properties(_tt-metal PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/third-party/tt-metal/tt_metal/libtt_metal.so"
+)
+
+add_library(_ttnn SHARED IMPORTED GLOBAL)
+set_target_properties(_ttnn PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/third-party/tt-metal/ttnn/_ttnn.so"
+)
+
+add_library(_device SHARED IMPORTED GLOBAL)
+set_target_properties(_device PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/third-party/tt-metal/tt_metal/third_party/umd/device/libdevice.so"
+)
+
+# Now create a logical interface library
+add_library(tt-metal INTERFACE)
+
+# Link the .so files into it
+target_link_libraries(tt-metal INTERFACE _tt-metal _ttnn _device)
+
+# Set architecture
+if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
+  set(ARCH_NAME "grayskull")
+  set(ARCH_EXTRA_DIR "grayskull")
+elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
+  set(ARCH_NAME "wormhole")
+  set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
+elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
+  set(ARCH_NAME "blackhole")
+  set(ARCH_EXTRA_DIR "blackhole")
+else()
+  message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
+endif()
+
+# Now all the incudes
+target_include_directories(tt-metal INTERFACE
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn/cpp
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn/cpp/ttnn/deprecated
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/api
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hostdevcommon/api
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd/device/api
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
+    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/tracy/public
+    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/taskflow
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_stl
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_stl/tt_stl
+    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_eager
+    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal-build/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6//include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
+    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
+    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,89 +1,62 @@
-# Some flags for tt-metal -- ccache + export compile commands for IDE if needed
-set(CMAKE_DISABLE_PRECOMPILE_HEADERS TRUE)
-set(ENABLE_CCACHE TRUE)
-set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
-set(TT_UNITY_BUILDS OFF)
-set(CPM_SOURCE_CACHE "${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache" CACHE STRING "Path to CPM source cache")
+# TT-Metal dependency
+if (BUILD_WORMHOLE_DECISION_TREE)
+  # Save previous CMake CXX flags
+  set(_PREV_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-# Save previous CMake CXX flags
-set(_PREV_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-dangling-reference") # Required to build with gcc
+  endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-dangling-reference")
+  # Some flags for tt-metal -- ccache + unity build + make sure that cpm cache stays in tt-metal dir
+  # set(CMAKE_DISABLE_PRECOMPILE_HEADERS TRUE)
+  # set(ENABLE_CCACHE TRUE)
+  # set(TT_UNITY_BUILDS OFF)  # Unity builds for some reason force recompilation every time
+  set(CPM_SOURCE_CACHE "${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache" CACHE STRING "Path to CPM source cache")
+
+  add_subdirectory(tt-metal)
+
+  # Restore previous CMake CXX flags
+  set(CMAKE_CXX_FLAGS "${_PREV_CMAKE_CXX_FLAGS}")
+  unset(_PREV_CMAKE_CXX_FLAGS)
+
+  set(METALIUM_INCLUDE_DIRS
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn/cpp
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn/cpp/ttnn/deprecated
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/api
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/include
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hostdevcommon/api
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd/device/api
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_stl
+      ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_stl/tt_stl
+  )
+
+  # Now wrap all the headers and .so files nicely into one target
+  if(NOT TARGET Metalium::Metal)
+    set(METALIUM_LIB_PATH "${CMAKE_BINARY_DIR}/lib")
+    find_library(TT_METAL_LIBRARY NAMES "tt_metal" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+    find_library(DEVICE_LIBRARY NAMES "device" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+
+    if(TT_METAL_LIBRARY)
+      add_library(Metalium::Metal SHARED IMPORTED GLOBAL)
+      set_target_properties(Metalium::Metal PROPERTIES
+          IMPORTED_LOCATION "${TT_METAL_LIBRARY}"
+          INTERFACE_INCLUDE_DIRECTORIES "${METALIUM_INCLUDE_DIRS}"
+      )
+      target_link_libraries(
+        Metalium::Metal
+        INTERFACE
+            ${DEVICE_LIBRARY}
+            nlohmann_json::nlohmann_json
+        )
+        message(STATUS "Successfully found libtt_metal.so at ${TT_METAL_LIBRARY}")
+      else()
+          message(FATAL_ERROR "libtt_metal.so not found in ${METALIUM_LIB_PATH}")
+      endif()
+  else()
+      message(STATUS "Metalium targets already exists")
+  endif()
 endif()
-
-add_subdirectory(tt-metal)
-
-# Restore previous CMake CXX flags
-set(CMAKE_CXX_FLAGS "${_PREV_CMAKE_CXX_FLAGS}")
-unset(_PREV_CMAKE_CXX_FLAGS)
-
-
-# Now wrap all the headers and .so files nicely into one target
-
-add_library(_tt-metal SHARED IMPORTED GLOBAL)
-set_target_properties(_tt-metal PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/third-party/tt-metal/tt_metal/libtt_metal.so"
-)
-
-add_library(_ttnn SHARED IMPORTED GLOBAL)
-set_target_properties(_ttnn PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/third-party/tt-metal/ttnn/_ttnn.so"
-)
-
-add_library(_device SHARED IMPORTED GLOBAL)
-set_target_properties(_device PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/third-party/tt-metal/tt_metal/third_party/umd/device/libdevice.so"
-)
-
-# Now create a logical interface library
-add_library(tt-metal INTERFACE)
-
-# Link the .so files into it
-target_link_libraries(tt-metal INTERFACE _tt-metal _ttnn _device)
-
-# Set architecture
-if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
-  set(ARCH_NAME "grayskull")
-  set(ARCH_EXTRA_DIR "grayskull")
-elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
-  set(ARCH_NAME "wormhole")
-  set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
-elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
-  set(ARCH_NAME "blackhole")
-  set(ARCH_EXTRA_DIR "blackhole")
-else()
-  message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
-endif()
-
-# Now all the incudes
-target_include_directories(tt-metal INTERFACE
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn/cpp
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/ttnn/cpp/ttnn/deprecated
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/api
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hostdevcommon/api
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd/device/api
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
-    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/tracy/public
-    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_metal/third_party/taskflow
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_stl
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_stl/tt_stl
-    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/tt_eager
-    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal-build/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6//include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
-    # ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
-    ${CMAKE_SOURCE_DIR}/third-party/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
-)


### PR DESCRIPTION
**Description**
We need to use tt-metal as dependency, to develop wormhole decision tree on top of it. 

Integration is inspired by tt-train integration with tt-metal: https://github.com/tenstorrent/tt-metal/blob/5147622f25fc1cdb13f83cca1762b7f623cc2b00/tt-train/sources/ttml/CMakeLists.txt#L48 

**What changed**
- Added third-party with tt-metal submodule
  - Note: tt-metal compilation with gcc requires  -Wno-dangling-reference flag
- Copy-pasted example for tt-metal `add_2_integers_in_compute_example`. You can see that the only think it does is linking with Metalium::Metal
- Updated README with instructions on how to build